### PR TITLE
createRootSpan in `finish.go`

### DIFF
--- a/command/finish.go
+++ b/command/finish.go
@@ -81,7 +81,7 @@ func (c *FinishCommand) RunContext(ctx context.Context, args []string) error {
 		return err
 	}
 
-	span, err := createSpan(tracer, traceParent, state)
+	span, err := createRootSpan(tracer, traceParent, state)
 	if err != nil {
 		return err
 	}

--- a/command/finish_test.go
+++ b/command/finish_test.go
@@ -69,6 +69,7 @@ func TestFinishingTrace(t *testing.T) {
 		assert.Equal(t, endTime, span.EndTime().UnixNano())
 		assert.Equal(t, startTrace.String(), span.SpanContext().TraceID().String())
 		assert.Equal(t, startSpan.String(), span.SpanContext().SpanID().String())
+                assert.False(t, span.Parent().HasSpanID())
 
 		attrs := mapFromAttributes(span.Attributes())
 		assert.Equal(t, "true", attrs["at_start"])


### PR DESCRIPTION
This PR changes the behavior of `finish` to create a root span.

The `createSpan` function injects the trace parent span. This is necessary when finishing a group or task. However, `finish` is only done once, and should create a root span.

It appears the problem was introduced in [this commit](https://github.com/Pondidum/Trace/commit/624a6a54d147d54462b27331d9ee8806cafc2026), specifically [this line](https://github.com/Pondidum/Trace/commit/624a6a54d147d54462b27331d9ee8806cafc2026#diff-3f8754af43a5270e653df2693fe5587084041ffa28bb338f40c5ecd98f7ae674L84) which replcaes `createRootSpan` with `createSpan`.

Testing locally, I get the output I'd expect:

```sh
export TRACEPARENT=$(trace start "why"); GROUP=$(trace group start "why-1"); trace task "$GROUP" go build; trace group finish "$GROUP"; trace finish
```

Yields a Honeycomb graph like this:

![image](https://github.com/Pondidum/Trace/assets/7310112/f20bb3a4-5b0b-412c-b618-ccf26cd31a54)

Fixes #5 