### PR TITLE
Get `ServiceName` from environment variable

### DIFF
--- a/tracing/agent_shell.go
+++ b/tracing/agent_shell.go
@@ -8,8 +8,14 @@ import (
 )
 
 func defaultAttributes() []attribute.KeyValue {
+
+	serviceName := os.getEnv("OTEL_SERVICE_NAME")
+	if serviceName == "" { 
+		serviceName = os.Getenv("SHELL")
+	}
+
 	return []attribute.KeyValue{
-		semconv.ServiceNameKey.String(os.Getenv("SHELL")),
+		semconv.ServiceNameKey.String(serviceName),
 		semconv.ServiceVersionKey.String("1.0.0"),
 	}
 }


### PR DESCRIPTION
With this PR, if a user sets `OTEL_SERVICE_NAME`, then the `trace` tool will respect that when run outside of CI.

Fixes #4 